### PR TITLE
Remove gtk-init call

### DIFF
--- a/gtk/loadlib.lisp
+++ b/gtk/loadlib.lisp
@@ -27,14 +27,6 @@
     (use-foreign-library :gtk)))
 
 (eval-when (:compile-toplevel)
-  (defcfun ("gtk_init" %gtk-init) :void (argc :pointer) (argv :pointer))
-
-  #+sbcl (sb-ext::set-floating-point-modes :traps nil)
-  (with-foreign-objects ((argc :int) (argv :pointer))
-    (setf (mem-ref argc :int) 0
-          (mem-ref argv :pointer) (foreign-alloc :string 
-                                                 :initial-element "program"))
-    (%gtk-init argc argv))
   (defcfun gtk-get-major-version :uint)
   (defcfun gtk-get-minor-version :uint)
   (when (and (>= (gtk-get-major-version) 3) (>= (gtk-get-minor-version) 2))


### PR DESCRIPTION
It turns out we could call gtk-get-major-version without gtk-init first.
